### PR TITLE
chore: add repo-local fnox Cloudflare token

### DIFF
--- a/fnox.toml
+++ b/fnox.toml
@@ -1,0 +1,2 @@
+[secrets]
+CLOUDFLARE_API_TOKEN = { provider = "onepass", value = "op://Professional/Personal Cloudflare API Token/password" }


### PR DESCRIPTION
## Overview

Adds the repo-scoped fnox Cloudflare token reference for Spotify Time Machine.

## Motivation

Keeps deployment secret resolution consistent across related repositories without committing credentials or changing runtime code.

## Implementation

- Adds `fnox.toml` mapping `CLOUDFLARE_API_TOKEN` to `op://Professional/Personal Cloudflare API Token/password`.
- Leaves application, Vercel, and dotenv workflow behavior unchanged.

## Validation

- `fnox check --non-interactive`
- `git diff --check`
- Prettier and TypeScript type-check passed.
- Local pre-push security hook passed with zero verified or unverified secrets.

## Scope and Safety

The commit contains only `fnox.toml`. Existing repository-wide lint findings are unchanged baseline issues and are outside this two-line configuration change; no token material is exposed.